### PR TITLE
Fixing issue with overriding window.$ on the servlet-side

### DIFF
--- a/Vis/Web/Scripts/gitflow-visualize.js
+++ b/Vis/Web/Scripts/gitflow-visualize.js
@@ -57,6 +57,7 @@ var GitFlowVisualize =
     
 		(function () {
     	'use strict';
+        var $ = AJS.$;
     	var self = {};
     	var data;
     	var constants = {


### PR DESCRIPTION
Adding reference to AJS.$ from within the GitFlowVisualize function. This will avoid issues with Stash client-side code relying on window.$
